### PR TITLE
refactor(all): cleanup API: remove unnecesary/duplicate code, improve JSDocs, rename vars and methods

### DIFF
--- a/demo-app/src/app/components/simple-form-error/simple-form-error.component.ts
+++ b/demo-app/src/app/components/simple-form-error/simple-form-error.component.ts
@@ -17,7 +17,7 @@ export class SimpleFormErrorComponent implements NgxFormErrorComponent {
 		/* empty constructor */
 	}
 
-	public checkForErrors(): void {
+	public subscribeToErrors(): void {
 		this.errors$.subscribe((errors: NgxFormFieldError[]) => {
 			this.errors = errors;
 		});

--- a/demo-app/src/app/components/translated-form-error/translated-form-error.component.ts
+++ b/demo-app/src/app/components/translated-form-error/translated-form-error.component.ts
@@ -23,7 +23,7 @@ export class TranslatedFormErrorComponent implements NgxFormErrorComponent, OnIn
 		});
 	}
 
-	public checkForErrors(): void {
+	public subscribeToErrors(): void {
 		this.errors$.subscribe((errors: NgxFormFieldError[]) => {
 			this.errors = errors;
 

--- a/demo-app/src/app/pages/ngx-forms-example/ngx-forms-example.component.html
+++ b/demo-app/src/app/pages/ngx-forms-example/ngx-forms-example.component.html
@@ -67,15 +67,12 @@
 					<mat-card-content>
 						<div>Has errors: {{ usernameField.hasErrors }}</div>
 						<div>Has 'required' error: {{ usernameField.hasError("required") }}</div>
-						<div>Is valid?: {{ usernameField.isValid() }}</div>
 						<div>Is touched? {{ usernameField.hasState("touched") }}</div>
 						<div>
-							'required' error:
-							<pre>{{ usernameField.getError("required") | json }}</pre>
+							'required' error: <pre>{{ usernameField.getError("required") | json }}</pre>
 						</div>
 						<div *ngIf="usernameField.hasErrors">
-							Errors:
-							<pre>{{ usernameField.errors | json }}</pre>
+							Errors: <pre>{{ usernameField.errors | json }}</pre>
 						</div>
 					</mat-card-content>
 				</mat-card>
@@ -85,15 +82,12 @@
 					<mat-card-content>
 						<div>Has errors: {{ passwordField.hasErrors }}</div>
 						<div>Has 'pattern' error: {{ passwordField.hasError("pattern") }}</div>
-						<div>Is pattern valid?: {{ passwordField.isValid("pattern") }}</div>
 						<div>Is touched? {{ passwordField.hasState("touched") }}</div>
 						<div>
-							'pattern' error:
-							<pre>{{ passwordField.getError("pattern") | json }}</pre>
+							'pattern' error: <pre>{{ passwordField.getError("pattern") | json }}</pre>
 						</div>
 						<div *ngIf="passwordField.hasErrors">
-							Errors:
-							<pre>{{ passwordField.errors | json }}</pre>
+							Errors: <pre>{{ passwordField.errors | json }}</pre>
 						</div>
 					</mat-card-content>
 				</mat-card>
@@ -103,15 +97,12 @@
 					<mat-card-content>
 						<div>Has errors: {{ confirmPasswordField.hasErrors }}</div>
 						<div>Has 'required' error: {{ confirmPasswordField.hasError("required") }}</div>
-						<div>Is required valid?: {{ confirmPasswordField.isValid("required") }}</div>
 						<div>Is touched? {{ confirmPasswordField.hasState("touched") }}</div>
 						<div>
-							'required' error:
-							<pre>{{ confirmPasswordField.getError("required") | json }}</pre>
+							'required' error: <pre>{{ confirmPasswordField.getError("required") | json }}</pre>
 						</div>
 						<div *ngIf="confirmPasswordField.hasErrors">
-							Errors:
-							<pre>{{ confirmPasswordField.errors | json }}</pre>
+							Errors: <pre>{{ confirmPasswordField.errors | json }}</pre>
 						</div>
 					</mat-card-content>
 				</mat-card>
@@ -131,7 +122,12 @@
 			<ul [hidden]="!usernameField.hasErrors && !passwordField.hasErrors && !confirmPasswordField.hasErrors">
 				<li [hidden]="!usernameField.hasErrors"><ng-template ngxFormErrors="username"></ng-template></li>
 
-				<li [hidden]="!passwordField.hasErrors"><ng-template ngxFormErrors="matchingPasswords.password"></ng-template></li>
+				<li [hidden]="!passwordField.hasErrors">
+					<ng-template
+						ngxFormErrors="matchingPasswords.password"
+						ngxFormErrorsFieldName="DEMO.FIELDS.PASSWORD_ALIAS"
+					></ng-template>
+				</li>
 
 				<li [hidden]="!confirmPasswordField.hasErrors">
 					<ng-template ngxFormErrors="matchingPasswords.confirmPassword"></ng-template>

--- a/demo-app/src/app/pages/reactive-forms-example/reactive-forms-example.component.html
+++ b/demo-app/src/app/pages/reactive-forms-example/reactive-forms-example.component.html
@@ -93,7 +93,6 @@
 					<mat-card-content>
 						<div>Has errors: {{ !!formGroup.get("username").errors }}</div>
 						<div>Has 'required' error: {{ formGroup.get("username").hasError("required") }}</div>
-						<!--<div>Is valid?: {{ formGroup.get("username").isValid() }}</div>-->
 						<div>
 							'required' error: <pre>{{ formGroup.get("username").getError("required") | json }}</pre>
 						</div>
@@ -109,7 +108,6 @@
 					<mat-card-content>
 						<div>Has errors: {{ !!formGroup.get("matchingPasswords.password").errors }}</div>
 						<div>Has 'pattern' error: {{ formGroup.get("matchingPasswords.password").hasError("pattern") }}</div>
-						<!--<div>Is valid?: {{ formGroup.get("matchingPasswords.password").isValid() }}</div>-->
 						<div>Is touched? {{ formGroup.get("matchingPasswords.password").touched }}</div>
 						<div>
 							'pattern' error: <pre>{{ formGroup.get("matchingPasswords.password").getError("pattern") | json }}</pre>
@@ -125,7 +123,6 @@
 					<mat-card-content>
 						<div>Has errors: {{ !!formGroup.get("matchingPasswords.confirmPassword").errors }}</div>
 						<div>Has 'required' error: {{ formGroup.get("matchingPasswords.confirmPassword").hasError("required") }}</div>
-						<!--<div>Is valid?: {{ formGroup.get("matchingPasswords.confirmPassword").isValid() }}</div>-->
 						<div>Is touched? {{ formGroup.get("matchingPasswords.confirmPassword").touched }}</div>
 						<div>
 							'required' error:

--- a/demo-app/src/app/pages/template-driven-forms-example/template-driven-forms-example.component.html
+++ b/demo-app/src/app/pages/template-driven-forms-example/template-driven-forms-example.component.html
@@ -99,7 +99,6 @@
 					<mat-card-content>
 						<div>Has errors: {{ !!usernameField.errors }}</div>
 						<div>Has 'required' error: {{ usernameField.hasError("required") }}</div>
-						<!--<div>Is valid?: {{ usernameField.isValid() }}</div>-->
 						<div>
 							'required' error: <pre>{{ usernameField.getError("required") | json }}</pre>
 						</div>
@@ -115,7 +114,6 @@
 					<mat-card-content>
 						<div>Has errors: {{ !!passwordField.errors }}</div>
 						<div>Has 'pattern' error: {{ passwordField.hasError("pattern") }}</div>
-						<!--<div>Is valid?: {{ passwordField.isValid() }}</div>-->
 						<div>Is touched? {{ passwordField.touched }}</div>
 						<div>
 							'pattern' error: <pre>{{ passwordField.getError("pattern") | json }}</pre>
@@ -131,7 +129,6 @@
 					<mat-card-content>
 						<div>Has errors: {{ !!confirmPasswordField.errors }}</div>
 						<div>Has 'required' error: {{ confirmPasswordField.hasError("required") }}</div>
-						<!--<div>Is valid?: {{ confirmPasswordField.isValid() }}</div>-->
 						<div>Is touched? {{ confirmPasswordField.touched }}</div>
 						<div>
 							'required' error: <pre>{{ confirmPasswordField.getError("required") | json }}</pre>

--- a/src/directives/form-errors-group.directive.ts
+++ b/src/directives/form-errors-group.directive.ts
@@ -2,7 +2,7 @@ import { Directive, Input, OnInit } from "@angular/core";
 
 /**
  * Directive that defines the group of the form model to be validated.
- * The directive exposes the group through the controller to allow access to it by wrapped ngxFormErrors directives.
+ * The directive exposes the group through the controller to allow access to it by wrapped {@link NgxFormErrorsDirective}(s).
  */
 @Directive({
 	selector: "[ngxFormErrorsGroup]"
@@ -10,7 +10,6 @@ import { Directive, Input, OnInit } from "@angular/core";
 export class NgxFormErrorsGroupDirective implements OnInit {
 	/**
 	 * The group of the form model
-	 * @param value - The group name
 	 */
 	@Input("ngxFormErrorsGroup")
 	public set group(value: string) {

--- a/src/form-error-component.intf.ts
+++ b/src/form-error-component.intf.ts
@@ -2,7 +2,8 @@ import { NgxFormFieldError } from "./form-error.intf";
 import { Observable } from "rxjs";
 
 /**
- * Describes an Error component to be dynamically created by the ngxFormErrors directive
+ * Describes an Error component to be dynamically created by the ngxFormErrors directive.
+ * `IMPORTANT:` The Error component should be provided in the {@link NgxFormErrorsModule}.forRoot() method and must implement this interface.
  */
 export interface NgxFormErrorComponent {
 	/**
@@ -14,5 +15,5 @@ export interface NgxFormErrorComponent {
 	 * Method to be called by the ngxFormErrors directive only. It subscribes to the errors$ observable to update
 	 * the current validation errors from the form control
 	 */
-	checkForErrors(): void;
+	subscribeToErrors(): void;
 }

--- a/src/form-error.intf.ts
+++ b/src/form-error.intf.ts
@@ -8,9 +8,9 @@ export interface NgxFormFieldError {
 	error: string;
 
 	/**
-	 * The name of the field whose validation has failed
+	 * The name of the FormControl whose validation has failed
 	 */
-	fieldName: string;
+	formControlName: string;
 
 	/**
 	 * The validation error message
@@ -22,11 +22,12 @@ export interface NgxFormFieldError {
 	 */
 	params: {
 		/**
-		 * Name of the validated field
+		 * Alias of the validated field. Defined via the "ngxFormErrorsFieldName" attribute of the {@link NgxFormErrorsDirective}
+		 * If no alias is defined for the field then this is the FormControl's name
 		 */
 		fieldName: string;
 		/**
-		 * Parameters passed to the actual Angular validator
+		 * Any parameters passed to the actual Angular validator
 		 */
 		[p: string]: any;
 	};

--- a/src/form-errors-config.intf.ts
+++ b/src/form-errors-config.intf.ts
@@ -6,7 +6,7 @@ import { InjectionToken, Type } from "@angular/core";
 export const NGX_FORM_ERRORS_CONFIG: InjectionToken<NgxFormErrorsConfig> = new InjectionToken<NgxFormErrorsConfig>("NgxFormErrorsConfig");
 
 /**
- * Definition of the configuration object for the NgxFormErrors module
+ * Definition of the configuration object for the {@link NgxFormErrorsModule}
  */
 export interface NgxFormErrorsConfig {
 	/**

--- a/src/form-errors.module.ts
+++ b/src/form-errors.module.ts
@@ -15,7 +15,7 @@ export class NgxFormErrorsModule {
 	 * Instantiates the services only once since they should be singletons
 	 * so the forRoot() should be called only by the AppModule
 	 * @link https://angular.io/guide/singleton-services#forroot
-	 * @param formErrorsConfig - Object containing the configuration (if any) for the Session service
+	 * @param formErrorsConfig - Object containing the configuration (if any) for the {@link NgxFormErrorsDirective}
 	 * @returns a module with providers
 	 */
 	public static forRoot(formErrorsConfig: NgxFormErrorsConfig): ModuleWithProviders {
@@ -28,19 +28,4 @@ export class NgxFormErrorsModule {
 			providers: [NgxFormErrorsMessageService, { provide: NGX_FORM_ERRORS_CONFIG, useValue: formErrorsConfig }]
 		};
 	}
-
-	// /**
-	//  * Prevents this module from being re-imported
-	//  * @link https://angular.io/guide/singleton-services#prevent-reimport-of-the-coremodule
-	//  * @param parentModule - the parent module
-	//  */
-	// public constructor(
-	// 	@Optional()
-	// 	@SkipSelf()
-	// 	parentModule: NgxFormErrorsModule
-	// ) {
-	// 	if (parentModule) {
-	// 		throw new Error("NgxFormErrorsModule is already loaded. Import it in the AppModule only");
-	// 	}
-	// }
 }

--- a/src/services/form-errors-message.service.spec.ts
+++ b/src/services/form-errors-message.service.spec.ts
@@ -47,7 +47,7 @@ describe("NgxFormErrorsMessageService", () => {
 		});
 	});
 
-	describe("getMessageForError", () => {
+	describe("getErrorMessage", () => {
 		const anotherErrorKey: string = "another-error";
 		const anotherErrorMessage: string = "another message";
 
@@ -58,10 +58,10 @@ describe("NgxFormErrorsMessageService", () => {
 				[anotherErrorKey]: anotherErrorMessage
 			};
 
-			expect(formErrorMessageService.getMessageForError(initialErrorKey)).toBe(initialMessages[initialErrorKey]);
-			expect(formErrorMessageService.getMessageForError(dummyErrorKey)).toBe(dummyErrorMessage[dummyErrorKey]);
-			expect(formErrorMessageService.getMessageForError(anotherErrorKey)).toBe(anotherErrorMessage);
-			expect(formErrorMessageService.getMessageForError("any-other-error")).toBeUndefined();
+			expect(formErrorMessageService.getErrorMessage(initialErrorKey)).toBe(initialMessages[initialErrorKey]);
+			expect(formErrorMessageService.getErrorMessage(dummyErrorKey)).toBe(dummyErrorMessage[dummyErrorKey]);
+			expect(formErrorMessageService.getErrorMessage(anotherErrorKey)).toBe(anotherErrorMessage);
+			expect(formErrorMessageService.getErrorMessage("any-other-error")).toBeUndefined();
 		});
 
 		it("should return the right message for the given group.error tuple or for the given error only or undefined if nothing related to that error exists", () => {
@@ -71,12 +71,12 @@ describe("NgxFormErrorsMessageService", () => {
 				[anotherErrorKey]: anotherErrorMessage
 			};
 
-			expect(formErrorMessageService.getMessageForError(initialErrorKey)).toBeUndefined();
-			expect(formErrorMessageService.getMessageForError(initialErrorKey, "some-group")).toBe(initialMessages[initialErrorKey]);
-			expect(formErrorMessageService.getMessageForError(dummyErrorKey)).toBeUndefined();
-			expect(formErrorMessageService.getMessageForError(dummyErrorKey, "dummy-group")).toBe(dummyErrorMessage[dummyErrorKey]);
-			expect(formErrorMessageService.getMessageForError(anotherErrorKey)).toBe(anotherErrorMessage);
-			expect(formErrorMessageService.getMessageForError(anotherErrorKey, "another-group")).toBe(anotherErrorMessage); // returns the message for the generic error
+			expect(formErrorMessageService.getErrorMessage(initialErrorKey)).toBeUndefined();
+			expect(formErrorMessageService.getErrorMessage(initialErrorKey, "some-group")).toBe(initialMessages[initialErrorKey]);
+			expect(formErrorMessageService.getErrorMessage(dummyErrorKey)).toBeUndefined();
+			expect(formErrorMessageService.getErrorMessage(dummyErrorKey, "dummy-group")).toBe(dummyErrorMessage[dummyErrorKey]);
+			expect(formErrorMessageService.getErrorMessage(anotherErrorKey)).toBe(anotherErrorMessage);
+			expect(formErrorMessageService.getErrorMessage(anotherErrorKey, "another-group")).toBe(anotherErrorMessage); // returns the message for the generic error
 		});
 	});
 
@@ -128,7 +128,7 @@ describe("NgxFormErrorsMessageService", () => {
 			expect(formErrorMessageService.getFieldName("any-other-field")).toBeUndefined();
 		});
 
-		it("should return the right message for the given group.fieldName tuple or for the given fieldName only or undefined if nothing related to that fieldName exists", () => {
+		it("should return the right message for the given group.formControlName tuple or for the given formControlName only or undefined if nothing related to that formControlName exists", () => {
 			formErrorMessageService.fieldNames = {
 				["some-group." + initialErrorKey]: initialFieldNames[initialFieldName],
 				["dummy-group." + dummyFieldNameKey]: dummyFieldName[dummyFieldNameKey],

--- a/src/services/form-errors-message.service.ts
+++ b/src/services/form-errors-message.service.ts
@@ -17,7 +17,7 @@ export interface NgxValidationErrorFieldNames {
 }
 
 /**
- * Service to add and retrieve error messages for the different validation errors returned by the ngxFormErrors directive
+ * Service to add and retrieve error messages for the different validation errors returned by the {@link NgxFormErrorsDirective}
  */
 @Injectable()
 export class NgxFormErrorsMessageService {
@@ -52,7 +52,7 @@ export class NgxFormErrorsMessageService {
 	 * @param error - The validation error (Angular validator name)
 	 * @param group - The model group to find a match for (if any)
 	 */
-	public getMessageForError(error: string, group?: string): string | undefined {
+	public getErrorMessage(error: string, group?: string): string | undefined {
 		let errorKey: string = error;
 
 		if (group) {


### PR DESCRIPTION
ISSUES CLOSED: #8

BREAKING CHANGE: removed/renamed some methods and properties:

   - removed `isValid()` from NgxFormErrorsDirective.
   - renamed `getMessageForError` to `getErrorMessage` in NgxFormErrorsMessageService.
   - renamed `fieldName` to `formControlName` in NgxFormFieldError.

## PR Checklist

Please check if your PR fulfills the following requirements:

-   [X] The commit message follows our guidelines: https://github.com/NationalBankBelgium/ngx-form-errors/blob/master/CONTRIBUTING.md#-commit-message-guidelines
-   [ ] Tests for the changes have been added (for bug fixes / features)
-   [X] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[X] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #8 

## What is the new behavior?
Clean API exposing only the necessary code without duplicate functionality.

## Does this PR introduce a breaking change?

```
[X] Yes
[ ] No
```