### PR TITLE
feat(service): add support for formControlName to provide error messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,12 +31,8 @@ Let's just have a look at the following example:
 <input type="text" formControlName="foo" />
 
 <!-- You need to add an element for each and every error to display a different message -->
-<div *ngIf="form.get('foo').hasError('required') && form.get('foo').touched">
-	Field is required
-</div>
-<div *ngIf="form.get('foo').hasError('minlength') && form.get('foo').dirty">
-	Min length is 5
-</div>
+<div *ngIf="form.get('foo').hasError('required') && form.get('foo').touched"> Field is required </div>
+<div *ngIf="form.get('foo').hasError('minlength') && form.get('foo').dirty"> Min length is 5 </div>
 <div *ngIf="form.get('foo').hasError('pattern') && form.get('foo').dirty">
 	Field must contain at least one uppercase, one lowercase, and one number
 </div>
@@ -63,14 +59,10 @@ You decide how to display the messages by defining your own Error component :sun
 <!-- Error component's template -->
 
 <!-- you can simply display the message 'as is' -->
-<div *ngFor="let error of errors" class="awesome-error-message">
-	{{ error.message }}
-</div>
+<div *ngFor="let error of errors" class="awesome-error-message"> {{ error.message }} </div>
 
 <!-- or you can use the error's data/properties to do something fancy -->
-<div *ngFor="let error of errors" [ngClass]="getErrorClass(error)">
-	{{ constructDisplayedErrorMessage(error) }}
-</div>
+<div *ngFor="let error of errors" [ngClass]="getErrorClass(error)"> {{ constructDisplayedErrorMessage(error) }} </div>
 ```
 
 And the messages are centralized in a service :astonished:
@@ -97,7 +89,7 @@ export class AppModule {
 		formErrorsMessageService.addErrorMessages({
 			required: "Field is required",
 			minlength: "Min length is 5",
-			pattern: "Field must contain at least one uppercase, one lowercase, and one number"
+			"foo.pattern": "Field must contain at least one uppercase, one lowercase, and one number"
 		});
 
 		// optionally, add the field names to the NgxFormErrorsMessageService
@@ -144,6 +136,10 @@ To know how to release NgxFormErrors, refer to [this page](/RELEASE.md).
 ### Christopher Cortes
 
 -   [@GitHub](https://github.com/christophercr)
+
+### Alexis Georges
+
+-   [@GitHub](https://github.com/SuperITMan)
 
 ## License
 

--- a/docs/DEV_GUIDE.md
+++ b/docs/DEV_GUIDE.md
@@ -191,9 +191,7 @@ Just wrap the `ngxFormErrors` directive inside a `<mat-error>` element and that'
 	<mat-form-field>
 		<input matInput type="text" formControlName="foo" placeholder="Foo" />
 
-		<mat-error>
-			<ng-template ngxFormErrors="foo"></ng-template>
-		</mat-error>
+		<mat-error> <ng-template ngxFormErrors="foo"></ng-template> </mat-error>
 	</mat-form-field>
 </form>
 ```
@@ -357,9 +355,7 @@ For example, you can use [ngx-translate](https://github.com/ngx-translate/core) 
 
 ```html
 <!-- You can translate the message and also pass the error params to have even more flexible translations -->
-<span *ngFor="let error of errors; trackBy: trackError" [ngClass]="getErrorClass()">
-	{{ error.message | translate: error.params }}
-</span>
+<span *ngFor="let error of errors; trackBy: trackError" [ngClass]="getErrorClass()"> {{ error.message | translate: error.params }} </span>
 ```
 
 Then in your translations you can use the params passed to the `translate` pipe:
@@ -405,6 +401,7 @@ For example, in this case we will add messages for the `required` and the `patte
 // inject the NgxFormErrorsMessageService to define the messages
 
 formErrorsMessageService.addErrorMessages({
+	"foo.required": "The foo field is obviously required!",
 	required: "This field is required",
 	pattern: "Your password must contain at least one uppercase, one lowercase, and one number"
 });
@@ -416,10 +413,9 @@ In this example the form control definition would be something like this:
 
 ```typescript
 this.formGroup = this.formBuilder.group({
-	foo: ["", Validators.compose([
-		Validators.required,
-		Validators.pattern("^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])[a-zA-Z0-9]+$")
-	])]
+	foo: ["", Validators.compose([Validators.required, Validators.pattern("^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])[a-zA-Z0-9]+$")])],
+	bar: ["", Validators.required],
+	bob: ["", Validators.required]
 });
 ```
 

--- a/package.json
+++ b/package.json
@@ -8,6 +8,11 @@
       "email": "christophercr@gmail.com",
       "name": "Christopher Cortes",
       "url": "https://github.com/christophercr"
+    },
+    {
+      "email": "alexis.georges@nbb.be",
+      "name": "Alexis Georges",
+      "url": "https://github.com/SuperITMan"
     }
   ],
   "main": "index.js",

--- a/src/directives/form-errors.directive.ts
+++ b/src/directives/form-errors.directive.ts
@@ -178,7 +178,11 @@ export class NgxFormErrorsDirective implements OnInit, OnChanges, OnDestroy {
 	 */
 	private constructFieldError(errorKey: string, error: any): NgxFormFieldError {
 		const errorGroup: string | undefined = this.formErrorsGroup && this.formErrorsGroup.group ? this.formErrorsGroup.group : undefined;
-		const validationMessage: string | undefined = this._formErrorsMessageService.getErrorMessage(errorKey, errorGroup);
+		const validationMessage: string | undefined = this._formErrorsMessageService.getErrorMessage(
+			errorKey,
+			this.formControlName,
+			errorGroup
+		);
 		let fieldName: string | undefined = this._formErrorsMessageService.getFieldName(this.formControlName, errorGroup);
 
 		// the alias provided via the directive will always take precedence

--- a/src/services/form-errors-message.service.spec.ts
+++ b/src/services/form-errors-message.service.spec.ts
@@ -58,25 +58,46 @@ describe("NgxFormErrorsMessageService", () => {
 				[anotherErrorKey]: anotherErrorMessage
 			};
 
-			expect(formErrorMessageService.getErrorMessage(initialErrorKey)).toBe(initialMessages[initialErrorKey]);
-			expect(formErrorMessageService.getErrorMessage(dummyErrorKey)).toBe(dummyErrorMessage[dummyErrorKey]);
-			expect(formErrorMessageService.getErrorMessage(anotherErrorKey)).toBe(anotherErrorMessage);
-			expect(formErrorMessageService.getErrorMessage("any-other-error")).toBeUndefined();
+			expect(formErrorMessageService.getErrorMessage(initialErrorKey, "test")).toBe(initialMessages[initialErrorKey]);
+			expect(formErrorMessageService.getErrorMessage(dummyErrorKey, "test")).toBe(dummyErrorMessage[dummyErrorKey]);
+			expect(formErrorMessageService.getErrorMessage(anotherErrorKey, "test")).toBe(anotherErrorMessage);
+			expect(formErrorMessageService.getErrorMessage("any-other-error", "test")).toBeUndefined();
 		});
 
-		it("should return the right message for the given group.error tuple or for the given error only or undefined if nothing related to that error exists", () => {
+		it("should return the right message for the given group.controlName.error tuple or for the given controlName.error tuple or for the given group.error tuple or for the given error only or undefined if nothing related to that error exists", () => {
+			const customRequiredErrorMessage: string = "some required message";
+			const customGroupRequiredErrorMessage: string = "some required group message";
+			const customControlNameRequiredErrorMessage: string = "some required controlName message";
+			const customGroupControlNameRequiredErrorMessage: string = "some required group controlName message";
+			const groupName: string = "custom-group";
+			const controlName: string = "custom-control-name";
+			const controlNameNoMsg: string = "control-name-without-linked-message";
+			const requiredErrorKey: string = "required";
+
 			formErrorMessageService.errorMessages = {
 				["some-group." + initialErrorKey]: initialMessages[initialErrorKey],
 				["dummy-group." + dummyErrorKey]: dummyErrorMessage[dummyErrorKey],
-				[anotherErrorKey]: anotherErrorMessage
+				[anotherErrorKey]: anotherErrorMessage,
+				[requiredErrorKey]: customRequiredErrorMessage,
+				[`${controlName}.${requiredErrorKey}`]: customControlNameRequiredErrorMessage,
+				[`${groupName}.${requiredErrorKey}`]: customGroupRequiredErrorMessage,
+				[`${groupName}.${controlName}.${requiredErrorKey}`]: customGroupControlNameRequiredErrorMessage
 			};
 
-			expect(formErrorMessageService.getErrorMessage(initialErrorKey)).toBeUndefined();
-			expect(formErrorMessageService.getErrorMessage(initialErrorKey, "some-group")).toBe(initialMessages[initialErrorKey]);
-			expect(formErrorMessageService.getErrorMessage(dummyErrorKey)).toBeUndefined();
-			expect(formErrorMessageService.getErrorMessage(dummyErrorKey, "dummy-group")).toBe(dummyErrorMessage[dummyErrorKey]);
-			expect(formErrorMessageService.getErrorMessage(anotherErrorKey)).toBe(anotherErrorMessage);
-			expect(formErrorMessageService.getErrorMessage(anotherErrorKey, "another-group")).toBe(anotherErrorMessage); // returns the message for the generic error
+			expect(formErrorMessageService.getErrorMessage(initialErrorKey, "test")).toBeUndefined();
+			expect(formErrorMessageService.getErrorMessage(initialErrorKey, "test", "some-group")).toBe(initialMessages[initialErrorKey]);
+			expect(formErrorMessageService.getErrorMessage(requiredErrorKey, controlName)).toBe(customControlNameRequiredErrorMessage);
+			expect(formErrorMessageService.getErrorMessage(requiredErrorKey, controlName, groupName)).toBe(
+				customGroupControlNameRequiredErrorMessage
+			);
+			expect(formErrorMessageService.getErrorMessage(requiredErrorKey, controlNameNoMsg)).toBe(customRequiredErrorMessage);
+			expect(formErrorMessageService.getErrorMessage(requiredErrorKey, controlNameNoMsg, groupName)).toBe(
+				customGroupRequiredErrorMessage
+			);
+			expect(formErrorMessageService.getErrorMessage(dummyErrorKey, "test")).toBeUndefined();
+			expect(formErrorMessageService.getErrorMessage(dummyErrorKey, "test", "dummy-group")).toBe(dummyErrorMessage[dummyErrorKey]);
+			expect(formErrorMessageService.getErrorMessage(anotherErrorKey, "test")).toBe(anotherErrorMessage);
+			expect(formErrorMessageService.getErrorMessage(anotherErrorKey, "test", "another-group")).toBe(anotherErrorMessage); // returns the message for the generic error
 		});
 	});
 

--- a/src/services/form-errors-message.service.ts
+++ b/src/services/form-errors-message.service.ts
@@ -50,17 +50,25 @@ export class NgxFormErrorsMessageService {
 	 * the error message matching that group and the validation error. If no validation error matches both, then it returns the one matching the validation error.
 	 * Otherwise it returns undefined.
 	 * @param error - The validation error (Angular validator name)
+	 * @param formControlName - The FormControl name
 	 * @param group - The model group to find a match for (if any)
 	 */
-	public getErrorMessage(error: string, group?: string): string | undefined {
-		let errorKey: string = error;
+	public getErrorMessage(error: string, formControlName: string, group?: string): string | undefined {
+		const controlNameErrorKey: string = `${formControlName}.${error}`;
+		let groupControlNameErrorKey: string | undefined;
+		let groupErrorKey: string | undefined;
 
 		if (group) {
-			errorKey = `${group}.${error}`; // concatenating group + error with a "."
+			groupErrorKey = `${group}.${error}`; // concatenating group + error with a "."
+			groupControlNameErrorKey = `${group}.${controlNameErrorKey}`; // concatenating group + error with a "."
 		}
 
-		if (this.errorMessages.hasOwnProperty(errorKey)) {
-			return this.errorMessages[errorKey];
+		if (groupControlNameErrorKey && this.errorMessages.hasOwnProperty(groupControlNameErrorKey)) {
+			return this.errorMessages[groupControlNameErrorKey];
+		} else if (this.errorMessages.hasOwnProperty(controlNameErrorKey)) {
+			return this.errorMessages[controlNameErrorKey];
+		} else if (groupErrorKey && this.errorMessages.hasOwnProperty(groupErrorKey)) {
+			return this.errorMessages[groupErrorKey];
 		} else if (this.errorMessages.hasOwnProperty(error)) {
 			return this.errorMessages[error];
 		} else {


### PR DESCRIPTION
ISSUES CLOSED: #19

## PR Checklist

Please check if your PR fulfills the following requirements:

-   [X] The commit message follows our guidelines: https://github.com/NationalBankBelgium/ngx-form-errors/blob/master/CONTRIBUTING.md#-commit-message-guidelines
-   [X] Tests for the changes have been added (for bug fixes / features)
-   [X] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
No support for formControlName in error messages.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #19

## What is the new behavior?

Support for formControlName in the definition of the error messages with the following priorities:

1. errorMessages[groupName.formControlName.errorKey]
2. errorMessages[formControlName.errorKey]
3. errorMessages[groupName.errorKey]
4. errorMessages[errorKey]
5. errorKey

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
