### PR TITLE
feat(service): add support for defining/finding error messages for a specific formControl name

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,13 +97,13 @@ export class AppModule {
 		formErrorsMessageService.addErrorMessages({
 			required: "Field is required",
 			minlength: "Min length is 5",
-			pattern: "Field must contain at least one uppercase, one lowercase, and one number"
+			"fooField.pattern": "Field must contain at least one uppercase, one lowercase, and one number"
 		});
 
 		// optionally, add the field names to the NgxFormErrorsMessageService
 		// so you can display this name in the validation message instead of the real field name!
 		formErrorsMessageService.addFieldNames({
-			foo: "Dummy foo field"
+			fooField: "Dummy foo field"
 		});
 	}
 }
@@ -144,6 +144,10 @@ To know how to release NgxFormErrors, refer to [this page](/RELEASE.md).
 ### Christopher Cortes
 
 -   [@GitHub](https://github.com/christophercr)
+
+### Alexis Georges
+
+-   [@GitHub](https://github.com/SuperITMan)
 
 ## License
 

--- a/docs/DEV_GUIDE.md
+++ b/docs/DEV_GUIDE.md
@@ -405,10 +405,13 @@ For example, in this case we will add messages for the `required` and the `patte
 // inject the NgxFormErrorsMessageService to define the messages
 
 formErrorsMessageService.addErrorMessages({
+	"foo.required": "Please provide the foo field",
 	required: "This field is required",
 	pattern: "Your password must contain at least one uppercase, one lowercase, and one number"
 });
 ```
+
+**IMPORTANT:** Notice how we have also defined a different message for the `required` error of the `foo` form control.
 
 Make sure that the errors you add messages for correspond to the validators that you added to the FormControl.
 
@@ -419,11 +422,14 @@ this.formGroup = this.formBuilder.group({
 	foo: ["", Validators.compose([
 		Validators.required,
 		Validators.pattern("^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])[a-zA-Z0-9]+$")
-	])]
+	])],
+	bar: ["", Validators.required]
 });
 ```
 
-From then on, whenever the field has a `required` or `pattern` validation error, the messages you added via the `NgxFormErrorsMessageService` will be displayed :muscle:
+From then on, whenever the fields have a `required` or `pattern` validation error, the messages you added via the `NgxFormErrorsMessageService` will be displayed :muscle:
+
+Moreover, in the `bar` field the generic `required` error message will be displayed, whereas in the `foo` field the specific `required` error message (`foo.required`) will be displayed!
 
 In case you have defined messages for the wrong validation errors, don't worry, you will notice it right away since the validation message that will be displayed
 will be completely different from what you have defined :wink:
@@ -442,13 +448,21 @@ However, in case you want to get those messages yourself too, you can call one o
 getErrorMessages(): NgxValidationErrorMessages;
 
 /**
- * Returns the error message matching the given validation error. Additionally, the model group can be specified to return
- * the error message matching that group and the validation error. If no validation error matches both, then it returns the one matching the validation error.
- * Otherwise it returns undefined.
+ * Tries to find the error message matching the given validation error. Additionally, the form control name and/or the model group
+ * can be specified to return the error message matching those as well as the validation error.
+ * This method does its best to find the message that fulfills all or some of the given parameters with the following precedence:
+ *
+ * 1.- errorMessages[groupName.formControlName.errorKey]
+ * 2.- errorMessages[formControlName.errorKey]
+ * 3.- errorMessages[groupName.errorKey]
+ * 4.- errorMessages[errorKey]
+ *
+ * It returns `undefined` if no message matching any of those params is found.
  * @param error - The validation error (Angular validator name)
+ * @param formControlName - The name of the FormControl
  * @param group - The model group to find a match for (if any)
  */
-getErrorMessage(error: string, group?: string): string | undefined;
+findErrorMessage(error: string, formControlName?: string, group?: string): string | undefined;
 ```
 
 ### <a name="adding-alias-globally-for-form-controls">Adding field names or alias globally

--- a/package.json
+++ b/package.json
@@ -8,6 +8,11 @@
       "email": "christophercr@gmail.com",
       "name": "Christopher Cortes",
       "url": "https://github.com/christophercr"
+    },
+    {
+      "email": "alexis.georges@nbb.be",
+      "name": "Alexis Georges",
+      "url": "https://github.com/SuperITMan"
     }
   ],
   "main": "index.js",

--- a/src/directives/form-errors.directive.ts
+++ b/src/directives/form-errors.directive.ts
@@ -178,7 +178,11 @@ export class NgxFormErrorsDirective implements OnInit, OnChanges, OnDestroy {
 	 */
 	private constructFieldError(errorKey: string, error: any): NgxFormFieldError {
 		const errorGroup: string | undefined = this.formErrorsGroup && this.formErrorsGroup.group ? this.formErrorsGroup.group : undefined;
-		const validationMessage: string | undefined = this._formErrorsMessageService.getErrorMessage(errorKey, errorGroup);
+		const validationMessage: string | undefined = this._formErrorsMessageService.findErrorMessage(
+			errorKey,
+			this.formControlName,
+			errorGroup
+		);
 		let fieldName: string | undefined = this._formErrorsMessageService.getFieldName(this.formControlName, errorGroup);
 
 		// the alias provided via the directive will always take precedence

--- a/src/services/form-errors-message.service.spec.ts
+++ b/src/services/form-errors-message.service.spec.ts
@@ -58,25 +58,50 @@ describe("NgxFormErrorsMessageService", () => {
 				[anotherErrorKey]: anotherErrorMessage
 			};
 
-			expect(formErrorMessageService.getErrorMessage(initialErrorKey)).toBe(initialMessages[initialErrorKey]);
-			expect(formErrorMessageService.getErrorMessage(dummyErrorKey)).toBe(dummyErrorMessage[dummyErrorKey]);
-			expect(formErrorMessageService.getErrorMessage(anotherErrorKey)).toBe(anotherErrorMessage);
-			expect(formErrorMessageService.getErrorMessage("any-other-error")).toBeUndefined();
+			expect(formErrorMessageService.findErrorMessage(initialErrorKey)).toBe(initialMessages[initialErrorKey]);
+			expect(formErrorMessageService.findErrorMessage(dummyErrorKey)).toBe(dummyErrorMessage[dummyErrorKey]);
+			expect(formErrorMessageService.findErrorMessage(anotherErrorKey)).toBe(anotherErrorMessage);
+			expect(formErrorMessageService.findErrorMessage("any-other-error")).toBeUndefined();
 		});
 
-		it("should return the right message for the given group.error tuple or for the given error only or undefined if nothing related to that error exists", () => {
+		it("should return the right message matching any of the given params or undefined if nothing is found related to that error", () => {
+			const customRequiredErrorMessage: string = "some required message";
+			const customGroupRequiredErrorMessage: string = "some required group message";
+			const customControlNameRequiredErrorMessage: string = "some required controlName message";
+			const customGroupControlNameRequiredErrorMessage: string = "some required group controlName message";
+			const groupName: string = "custom-group";
+			const controlName: string = "custom-control-name";
+			const controlNameNoMsg: string = "control-name-without-linked-message";
+			const requiredErrorKey: string = "required";
+
 			formErrorMessageService.errorMessages = {
 				["some-group." + initialErrorKey]: initialMessages[initialErrorKey],
 				["dummy-group." + dummyErrorKey]: dummyErrorMessage[dummyErrorKey],
-				[anotherErrorKey]: anotherErrorMessage
+				[anotherErrorKey]: anotherErrorMessage,
+				[requiredErrorKey]: customRequiredErrorMessage,
+				[`${controlName}.${requiredErrorKey}`]: customControlNameRequiredErrorMessage,
+				[`${groupName}.${requiredErrorKey}`]: customGroupRequiredErrorMessage,
+				[`${groupName}.${controlName}.${requiredErrorKey}`]: customGroupControlNameRequiredErrorMessage
 			};
 
-			expect(formErrorMessageService.getErrorMessage(initialErrorKey)).toBeUndefined();
-			expect(formErrorMessageService.getErrorMessage(initialErrorKey, "some-group")).toBe(initialMessages[initialErrorKey]);
-			expect(formErrorMessageService.getErrorMessage(dummyErrorKey)).toBeUndefined();
-			expect(formErrorMessageService.getErrorMessage(dummyErrorKey, "dummy-group")).toBe(dummyErrorMessage[dummyErrorKey]);
-			expect(formErrorMessageService.getErrorMessage(anotherErrorKey)).toBe(anotherErrorMessage);
-			expect(formErrorMessageService.getErrorMessage(anotherErrorKey, "another-group")).toBe(anotherErrorMessage); // returns the message for the generic error
+			expect(formErrorMessageService.findErrorMessage(initialErrorKey)).toBeUndefined();
+			expect(formErrorMessageService.findErrorMessage(initialErrorKey, undefined, "some-group")).toBe(
+				initialMessages[initialErrorKey]
+			);
+			expect(formErrorMessageService.findErrorMessage(requiredErrorKey, controlName)).toBe(customControlNameRequiredErrorMessage);
+			expect(formErrorMessageService.findErrorMessage(requiredErrorKey, controlName, groupName)).toBe(
+				customGroupControlNameRequiredErrorMessage
+			);
+			expect(formErrorMessageService.findErrorMessage(requiredErrorKey, controlNameNoMsg)).toBe(customRequiredErrorMessage);
+			expect(formErrorMessageService.findErrorMessage(requiredErrorKey, controlNameNoMsg, groupName)).toBe(
+				customGroupRequiredErrorMessage
+			);
+			expect(formErrorMessageService.findErrorMessage(dummyErrorKey)).toBeUndefined();
+			expect(formErrorMessageService.findErrorMessage(dummyErrorKey, undefined, "dummy-group")).toBe(
+				dummyErrorMessage[dummyErrorKey]
+			);
+			expect(formErrorMessageService.findErrorMessage(anotherErrorKey)).toBe(anotherErrorMessage);
+			expect(formErrorMessageService.findErrorMessage(anotherErrorKey, undefined, "another-group")).toBe(anotherErrorMessage); // returns the message for the generic error
 		});
 	});
 

--- a/src/services/form-errors-message.service.ts
+++ b/src/services/form-errors-message.service.ts
@@ -46,26 +46,27 @@ export class NgxFormErrorsMessageService {
 	}
 
 	/**
-	 * Returns the error message matching the given validation error. Additionally, the model group can be specified to return
-	 * the error message matching that group and the validation error. If no validation error matches both, then it returns the one matching the validation error.
-	 * Otherwise it returns undefined.
+	 * Tries to find the error message matching the given validation error. Additionally, the form control name and/or the model group
+	 * can be specified to return the error message matching those as well as the validation error.
+	 * This method does its best to find the message that fulfills all or some of the given parameters with the following precedence:
+	 *
+	 * 1.- errorMessages[groupName.formControlName.errorKey]
+	 * 2.- errorMessages[formControlName.errorKey]
+	 * 3.- errorMessages[groupName.errorKey]
+	 * 4.- errorMessages[errorKey]
+	 *
+	 * It returns `undefined` if no message matching any of those params is found.
 	 * @param error - The validation error (Angular validator name)
+	 * @param formControlName - The name of the FormControl
 	 * @param group - The model group to find a match for (if any)
 	 */
-	public getErrorMessage(error: string, group?: string): string | undefined {
-		let errorKey: string = error;
-
-		if (group) {
-			errorKey = `${group}.${error}`; // concatenating group + error with a "."
-		}
-
-		if (this.errorMessages.hasOwnProperty(errorKey)) {
-			return this.errorMessages[errorKey];
-		} else if (this.errorMessages.hasOwnProperty(error)) {
-			return this.errorMessages[error];
-		} else {
-			return undefined;
-		}
+	public findErrorMessage(error: string, formControlName?: string, group?: string): string | undefined {
+		return (
+			(group && formControlName && this.errorMessages[`${group}.${formControlName}.${error}`]) ||
+			(formControlName && this.errorMessages[`${formControlName}.${error}`]) ||
+			(group && this.errorMessages[`${group}.${error}`]) ||
+			this.errorMessages[error]
+		);
 	}
 
 	/**


### PR DESCRIPTION
ISSUES CLOSED: #19

## PR Checklist

Please check if your PR fulfills the following requirements:

-   [X] The commit message follows our guidelines: https://github.com/NationalBankBelgium/ngx-form-errors/blob/master/CONTRIBUTING.md#-commit-message-guidelines
-   [X] Tests for the changes have been added (for bug fixes / features)
-   [X] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[X] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #19

## What is the new behavior?
Support for _formControlName_ in the definition of the error messages with the following precedence:

- errorMessages[**groupName.formControlName.errorKey**]
- errorMessages[**formControlName.errorKey**]
- errorMessages[**groupName.errorKey**]
- errorMessages[**errorKey**]
- **errorKey**
- _undefined_ (if nothing related to the errorKey is found)

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
@SuperITMan @carlo-nomes @nicanac this PR replaces #20.

It contains the same changes and also all the fixes for the remarks given in the other PR:
- adapted unit tests to use the current scenarios and just add the new ones
- renamed the `getErrorMessage()` function of the `NgxFormErrorsMessageService` to `findErrorMessage()` to be more descriptive about its actual functionality.
- simplified the implementation of the `findErrorMessage()` as suggested by @carlo-nomes 
- added more content to the `DEV_GUIDE.md` explaining the new feature