### PR TITLE
feat(service): adapt demo to show the new feature about defining messages for specific form controls

### DIFF
--- a/demo-app/src/app/app.module.ts
+++ b/demo-app/src/app/app.module.ts
@@ -80,7 +80,7 @@ export class AppModule {
 
 		errorMessageService.addErrorMessages({
 			required: "DEMO.FORM_VALIDATION.WITH_NGX_FORM_ERRORS.REQUIRED",
-			// "matchingPasswords.password.required": "DEMO.FORM_VALIDATION.WITH_NGX_FORM_ERRORS.REQUIRED",
+			"matchingPasswords.password.required": "DEMO.FORM_VALIDATION.WITH_NGX_FORM_ERRORS.PASSWORD_REQUIRED",
 			minlength: "DEMO.FORM_VALIDATION.WITH_NGX_FORM_ERRORS.PASSWORD.MIN_LENGTH",
 			maxlength: "DEMO.FORM_VALIDATION.WITH_NGX_FORM_ERRORS.PASSWORD.MAX_LENGTH",
 			pattern: "DEMO.FORM_VALIDATION.WITH_NGX_FORM_ERRORS.PASSWORD.PATTERN"
@@ -88,7 +88,7 @@ export class AppModule {
 
 		errorMessageService.addFieldNames({
 			username: "DEMO.FIELDS.USER_NAME",
-			"matchingPasswords.password": "DEMO.FIELDS.PASSWORD_ALIAS",
+			"matchingPasswords.password": "not used, the alias defined via the directive takes precedence over this",
 			"matchingPasswords.confirmPassword": "DEMO.FIELDS.CONFIRM_PASSWORD"
 		});
 	}

--- a/demo-app/src/assets/translations/en.json
+++ b/demo-app/src/assets/translations/en.json
@@ -29,10 +29,12 @@
       },
       "WITH_NGX_FORM_ERRORS": {
         "REQUIRED": "{{fieldName}} is required",
+        "PASSWORD_REQUIRED": "{{fieldName}} must be provided",
         "USER_NAME": {
           "UNIQUE": "Your username has already been taken"
         },
         "PASSWORD": {
+          "MAX_LENGTH": "Password cannot be more than {{requiredLength}} characters long",
           "MIN_LENGTH": "Password must be at least {{requiredLength}} characters long",
           "PATTERN": "Your password must contain at least one uppercase, one lowercase, and one number"
         },

--- a/demo-app/src/assets/translations/fr.json
+++ b/demo-app/src/assets/translations/fr.json
@@ -29,10 +29,12 @@
       },
       "WITH_NGX_FORM_ERRORS": {
         "REQUIRED": "{{fieldName}} est nécessaire",
+        "PASSWORD_REQUIRED": "{{fieldName}} doit être fourni",
         "USER_NAME": {
           "UNIQUE": "Votre nom d'utilisateur a déjà été pris"
         },
         "PASSWORD": {
+          "MAX_LENGTH": "Mot de passe ne peut pas y avoir plus de {{requiredLength}} caractères",
           "MIN_LENGTH": "Mot de passe doit comporter au moins {{requiredLength}} caractères",
           "PATTERN": "Votre mot de passe doit contenir au moins une majuscule, une minuscule et un chiffre."
         },

--- a/demo-app/src/assets/translations/nl.json
+++ b/demo-app/src/assets/translations/nl.json
@@ -29,10 +29,12 @@
       },
       "WITH_NGX_FORM_ERRORS": {
         "REQUIRED": "{{fieldName}} is verplicht",
+        "PASSWORD_REQUIRED": "{{fieldName}} moet worden gegeven",
         "USER_NAME": {
           "UNIQUE": "Uw gebruikersnaam is al in gebruik"
         },
         "PASSWORD": {
+          "MAX_LENGTH": "Wachtwoord mag niet meer dan {{requiredLength}} tekens lang zijn",
           "MIN_LENGTH": "Wachtwoord moet minimaal {{requiredLength}} tekens lang zijn",
           "PATTERN": "Uw Wachtwoord moet minimaal één hoofdletter, één kleine letter en één cijfer bevatten"
         },


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [X] The commit message follows our guidelines: https://github.com/NationalBankBelgium/ngx-form-errors/blob/master/CONTRIBUTING.md#-commit-message-guidelines
-   [ ] Tests for the changes have been added (for bug fixes / features)
-   [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The demo doesn't show the new feature added in #22.
Moreover, there is no "breaking change" entry in the logs to warn the users about the rename of a method in the `NgxFormErrorMessageService`.

## What is the new behavior?
The demo app now also shows how a message can be provided for a specific form control.

## Does this PR introduce a breaking change?

```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
The commit message includes a "breaking change" section to explain the changes done in #22.