### PR TITLE
fix(directive): fetch correctly the form control's validation errors when it is already invalid before the directive is instantiated

### DIFF
--- a/src/directives/form-errors.directive.ts
+++ b/src/directives/form-errors.directive.ts
@@ -142,7 +142,7 @@ export class NgxFormErrorsDirective implements OnInit, OnChanges, OnDestroy {
 		}
 
 		this._controlChangesSubscription = this._formControl.statusChanges
-			.pipe(map<ValidationErrors | null, ValidationErrors>(() => this._formControl.errors || {}))
+			.pipe(map<string, ValidationErrors>(() => this._formControl.errors || {}))
 			.subscribe((errors: ValidationErrors) => {
 				const fieldErrors: NgxFormFieldError[] = [];
 
@@ -155,8 +155,8 @@ export class NgxFormErrorsDirective implements OnInit, OnChanges, OnDestroy {
 				this._controlErrorsSubj.next(fieldErrors);
 			});
 
-		// trigger initial validation in case the field is untouched
-		if (this._formControl.untouched) {
+		// trigger initial validation in case the field is already invalid
+		if (this._formControl.invalid) {
 			this._formControl.updateValueAndValidity({ onlySelf: true, emitEvent: true });
 		}
 	}

--- a/src/form-errors-config.intf.ts
+++ b/src/form-errors-config.intf.ts
@@ -1,4 +1,5 @@
 import { InjectionToken, Type } from "@angular/core";
+import { NgxFormErrorComponent } from "./form-error-component.intf";
 
 /**
  * The InjectionToken version of the config name
@@ -8,9 +9,10 @@ export const NGX_FORM_ERRORS_CONFIG: InjectionToken<NgxFormErrorsConfig> = new I
 /**
  * Definition of the configuration object for the {@link NgxFormErrorsModule}
  */
-export interface NgxFormErrorsConfig {
+export interface NgxFormErrorsConfig<ErrorComponent extends NgxFormErrorComponent = NgxFormErrorComponent> {
 	/**
-	 * Error component to be dynamically created by the ngxFormErrors directive which will display the validation errors
+	 * Error component to be dynamically created by the ngxFormErrors directive which will display the validation errors.
+	 * This component should implement the {@link NgxFormErrorComponent} interface.
 	 */
-	formErrorComponent: Type<any>;
+	formErrorComponent: Type<ErrorComponent>;
 }


### PR DESCRIPTION
ISSUES CLOSED: #28

## PR Checklist

Please check if your PR fulfills the following requirements:

-   [X] The commit message follows our guidelines: https://github.com/NationalBankBelgium/ngx-form-errors/blob/master/CONTRIBUTING.md#-commit-message-guidelines
-   [X] Tests for the changes have been added (for bug fixes / features)
-   [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[X] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #28

## What is the new behavior?
- the `NgxFormErrorsDirective` now fetches the validation errors when the form control is already invalid regardless of whether it is dirty, touched, etc.
- minor adaptations done in the directive's unit tests to simplify some code

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
Added another commit to enhance the typings of the `NgxFormErrorsConfig` interface to enforce   the right type for the formErrorComponent