### PR TITLE
fix(release): add 'rc' branches in .travis.yml to make Travis trigger release builds also in those

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ env:
 branches:
   only:
     - master
-    - /^\d+\.\d+\.\d(-alpha\.\d+|-beta\.\d+)?$/
+    - /^\d+\.\d+\.\d(-alpha\.\d+|-beta\.\d+|-rc\.\d+)?$/
 
 cache:
   directories:

--- a/package.json
+++ b/package.json
@@ -143,7 +143,6 @@
   "config": {
     "commitizen": {
       "path": "node_modules/cz-customizable"
-    },
-    "nightlyVersion": "1.0.0-rc.1"
+    }
   }
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [X] The commit message follows our guidelines: https://github.com/NationalBankBelgium/ngx-form-errors/blob/master/CONTRIBUTING.md#-commit-message-guidelines
-   [ ] Tests for the changes have been added (for bug fixes / features)
-   [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

The current configuration of Travis doesn't trigger builds if we release an RC version.

## What is the new behavior?
Now the RC tags trigger Travis builds.

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
Also removed the `nightlyVersion` field that was recently added in the `package.json` because there are no nightly builds set up for this repo.