### PR TITLE
docs(developer-guide): include developer guide in compodoc generated docs

### DIFF
--- a/.compodocrc.json
+++ b/.compodocrc.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "./node_modules/@compodoc/compodoc/src/config/schema.json",
+  "theme": "material",
+  "tsconfig": "./tsconfig.json",
+  "output": "./reports/api-docs/ngx-form-errors",
+  "includes": "./docs",
+  "includesName": "Developer Guide"
+}

--- a/docs/DEV_GUIDE.md
+++ b/docs/DEV_GUIDE.md
@@ -28,11 +28,11 @@
 
 ---
 
-## <a name="ngx-form-errors">ngxFormErrors directive
+## <a name="ngx-form-errors"></a>ngxFormErrors directive
 
 This directive creates an Error component dynamically where the validation messages will be displayed. See [Defining the Error component to use](#defining-error-component).
 
-### <a name="binding-form-control">Binding to a FormControl
+### <a name="binding-form-control"></a>Binding to a FormControl
 
 Let's start by defining the Angular form group:
 
@@ -60,7 +60,7 @@ At runtime, the validation messages are displayed by the Error component that is
 
 Remember that you need to provide the Error component that will be created by this directive. See [Defining the Error component to use](#defining-error-component).
 
-### <a name="validation-errors">Validation errors emitted
+### <a name="validation-errors"></a>Validation errors emitted
 
 In order to display the validation messages in the Error component, the `ngxFormErrors` directive emits an array of error objects containing the following information:
 
@@ -198,7 +198,7 @@ Just wrap the `ngxFormErrors` directive inside a `<mat-error>` element and that'
 </form>
 ```
 
-In fact, we have integrated [Angular Material](https://material.angular.io) in our [demo app](../demo-app). Check it out!
+In fact, we have integrated [Angular Material](https://material.angular.io) in our [demo app](https://github.com/NationalBankBelgium/ngx-form-errors/tree/master/demo-app). Check it out!
 
 You can also integrate the directive with other UI libraries. This is really simple since you just need to use an `<ng-template>` element to use the `ngxFormErrors` directive so you can place it anywhere in the template according to your needs :wink:
 
@@ -385,7 +385,7 @@ formErrorsMessageService.addErrorMessages({
 });
 ```
 
-In fact, we have integrated [ngx-translate](https://github.com/ngx-translate/core) in our [demo app](../demo-app). Check it out!
+In fact, we have integrated [ngx-translate](https://github.com/ngx-translate/core) in our [demo app](https://github.com/NationalBankBelgium/ngx-form-errors/tree/master/demo-app). Check it out!
 
 The same functionality can be achieved with any other i18n library, you just need to integrate it in your Error component :wink:
 
@@ -466,7 +466,7 @@ getErrorMessages(): NgxValidationErrorMessages;
 findErrorMessage(error: string, formControlName?: string, group?: string): string | undefined;
 ```
 
-### <a name="adding-alias-globally-for-form-controls">Adding field names or alias globally
+### <a name="adding-alias-globally-for-form-controls"></a>Adding field names or alias globally
 
 Sometimes the names of the fields in your model (and therefore in your form) are not really descriptive for the end user,
 in those cases you might want to display better error messages with meaningful field names.

--- a/docs/summary.json
+++ b/docs/summary.json
@@ -1,0 +1,6 @@
+[
+  {
+    "title": "Developer Guide",
+    "file": "DEV_GUIDE.md"
+  }
+]

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "docs": "npm run docs:clean && npm run docs:generate",
     "docs:clean": "npx rimraf reports/api-docs",
     "docs:coverage": "npm run docs:generate -- --coverageTest 85 --coverageTestThresholdFail true",
-    "docs:generate": "node ./node_modules/@compodoc/compodoc/bin/index-cli src --theme material --tsconfig ./tsconfig.json --output ./reports/api-docs/ngx-form-errors",
+    "docs:generate": "node ./node_modules/@compodoc/compodoc/bin/index-cli src",
     "docs:serve": "npm run docs:generate -- --watch --serve --port 4321",
     "docs:publish": "bash ./gh-deploy.sh --trace",
     "generate:changelog": "conventional-changelog -p angular -i CHANGELOG.md -s -r 0",


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [X] The commit message follows our guidelines: https://github.com/NationalBankBelgium/ngx-form-errors/blob/master/CONTRIBUTING.md#-commit-message-guidelines
-   [ ] Tests for the changes have been added (for bug fixes / features)
-   [X] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[X] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
The Developer Guide is not included in the generated docs by compodoc. Ideally, this Dev Guide should not only be reachable via Github but also via the published docs website (when that is available).

## What is the new behavior?
- refactor compodoc configuration in a `.compodocrc.json` file to make it more readable and flexible in order to include the different MD files under `/docs` to create the Developer Guide.
- fix not well-formed links and adapt some urls in the Developer Guide

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```