### PR TITLE
fix(demo): issue when opening ngx-form-error page in demo apps

### DIFF
--- a/demo-app/ng7/src/app/pages/ngx-forms-example/ngx-forms-example.component.html
+++ b/demo-app/ng7/src/app/pages/ngx-forms-example/ngx-forms-example.component.html
@@ -23,7 +23,7 @@
 							/>
 							<mat-error>
 								<ng-template
-									ngxFormErrors="matchingPasswords.password"
+									ngxFormErrors="password"
 									ngxFormErrorsFieldName="DEMO.FIELDS.PASSWORD_ALIAS"
 									#passwordField="ngxFormErrors"
 								></ng-template>
@@ -40,10 +40,7 @@
 								required
 							/>
 							<mat-error>
-								<ng-template
-									ngxFormErrors="matchingPasswords.confirmPassword"
-									#confirmPasswordField="ngxFormErrors"
-								></ng-template>
+								<ng-template ngxFormErrors="confirmPassword" #confirmPasswordField="ngxFormErrors"></ng-template>
 							</mat-error>
 						</mat-form-field>
 					</div>

--- a/demo-app/ng7/src/app/parent-error-state-matcher.ts
+++ b/demo-app/ng7/src/app/parent-error-state-matcher.ts
@@ -5,8 +5,8 @@ import { FormControl, FormGroupDirective, NgForm } from "@angular/forms";
 export class ParentErrorStateMatcher implements ErrorStateMatcher {
 	public isErrorState(control: FormControl | null, form: FormGroupDirective | NgForm | null): boolean {
 		const isSubmitted: boolean = !!(form && form.submitted);
-		const formGroupValid: boolean = !!(form && form.valid);
+		const formGroupInvalid: boolean = !!(form && form.invalid);
 
-		return !!((control && control.invalid && (control.dirty || control.touched)) || isSubmitted || formGroupValid);
+		return !!(control && (control.invalid || formGroupInvalid) && (control.dirty || control.touched || isSubmitted));
 	}
 }

--- a/demo-app/ng8/src/app/pages/ngx-forms-example/ngx-forms-example.component.html
+++ b/demo-app/ng8/src/app/pages/ngx-forms-example/ngx-forms-example.component.html
@@ -23,7 +23,7 @@
 							/>
 							<mat-error>
 								<ng-template
-									ngxFormErrors="matchingPasswords.password"
+									ngxFormErrors="password"
 									ngxFormErrorsFieldName="DEMO.FIELDS.PASSWORD_ALIAS"
 									#passwordField="ngxFormErrors"
 								></ng-template>
@@ -40,10 +40,7 @@
 								required
 							/>
 							<mat-error>
-								<ng-template
-									ngxFormErrors="matchingPasswords.confirmPassword"
-									#confirmPasswordField="ngxFormErrors"
-								></ng-template>
+								<ng-template ngxFormErrors="confirmPassword" #confirmPasswordField="ngxFormErrors"></ng-template>
 							</mat-error>
 						</mat-form-field>
 					</div>

--- a/demo-app/ng8/src/app/parent-error-state-matcher.ts
+++ b/demo-app/ng8/src/app/parent-error-state-matcher.ts
@@ -5,8 +5,8 @@ import { FormControl, FormGroupDirective, NgForm } from "@angular/forms";
 export class ParentErrorStateMatcher implements ErrorStateMatcher {
 	public isErrorState(control: FormControl | null, form: FormGroupDirective | NgForm | null): boolean {
 		const isSubmitted: boolean = !!(form && form.submitted);
-		const formGroupValid: boolean = !!(form && form.valid);
+		const formGroupInvalid: boolean = !!(form && form.invalid);
 
-		return !!((control && control.invalid && (control.dirty || control.touched)) || isSubmitted || formGroupValid);
+		return !!(control && (control.invalid || formGroupInvalid) && (control.dirty || control.touched || isSubmitted));
 	}
 }


### PR DESCRIPTION
When opening ngx-form-error page this raise an jasvscript error.

ISSUES CLOSED: #43

## PR Checklist

Please check if your PR fulfills the following requirements:

-   [X] The commit message follows our guidelines: https://github.com/NationalBankBelgium/ngx-form-errors/blob/master/CONTRIBUTING.md#-commit-message-guidelines
-   [X] Tests for the changes have been added (for bug fixes / features)
-   [X] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

Bugfix issue when opening ngx-form-error page
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Raise an javascript error and do not render the page

Issue Number: #43 

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
