### PR TITLE
ci(release): add missing npm token in ".npmrc" file in the release job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,8 +86,6 @@ jobs:
           echo "Main ENV    : ${{ env.IS_MAIN_ENVIRONMENT }}"
           NODE_VERSION="$(node -v)"
           echo "Node version: $NODE_VERSION"
-          # This ensures that we are authenticated without requiring to have an actual .npmrc file within the project
-          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" >> ~/.npmrc
 
       - name: Install dependencies
         run: |
@@ -149,6 +147,10 @@ jobs:
           # cfr scripts/_ghactions-group.sh
           mkdir -p $LOGS_DIR
           touch $LOGS_FILE
+
+      # This ensures that we are authenticated without requiring to have an actual .npmrc file within the project
+      - name: Set npm token
+        run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" >> ~/.npmrc
 
       - name: Release
         run: npm run release:publish


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [X] The commit message follows our guidelines: https://github.com/NationalBankBelgium/ngx-form-errors/blob/master/CONTRIBUTING.md#-commit-message-guidelines
-   [ ] Tests for the changes have been added (for bug fixes / features)
-   [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[X] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

The CI release job cannot publish to npmjs.org because the token is not present in the ".npmrc" file.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

The CI release job can now publish to npmjs.org.

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
